### PR TITLE
Fix afrikaans book names

### DIFF
--- a/Afrikaans/books.h
+++ b/Afrikaans/books.h
@@ -1,10 +1,10 @@
-Books[] = { "Genesis", "Eksodus", "Levitikus", "Numeri", "Deuteronomium", "Josua", "Rigters",
+Books[] = { "Génesis", "Eksodus", "Levítikus", "Númeri", "Deuteronomium", "Josua", "Rigters",
             "Rut", "1 Samuel", "2 Samuel", "1 Konings", "2 Konings", "1 Kronieke", "2 Kronieke",
-            "Esra", "Nehemia", "Ester", "Job", "Psalms", "Spreuke van Salomo", "Prediker", "Hooglied van Salomo",
-            "Jesaja", "Jeremia", "Klaagliedere van Jeremia", "Esegiël", "Daniël", "Hosea", "Joël", "Amos",
-            "Obadja", "Jona", "Miga", "Nahum", "Habakuk", "Sefanja", "Haggai", "Sagaria", "Maleagi",
-            "Matteus", "Markus", "Lukas", "Johannes", "Die handelinge van die apostels", "Romeine", "1 Korintiërs",
-            "2 Korintiërs", "Galasiërs", "Effesiërs", "Filippense", "Kolossense", "1 Tessalonisense", "2 Tessalonisense",
-            "1 Timoteus", "2 Timoteus", "Titus", "Filemon", "Hebreërs", "Jakobus", "1 Petrus", "2 Petrus", "1 Johannes",
-            "2 Johannes", "3 Johannes", "Judas", "Die openbaring", NULL
+            "Esra", "Nehemia", "Ester", "Job", "Psalms", "Spreuke", "Prediker", "Hooglied",
+            "Jesaja", "Jeremia", "Klaagliedere van Jeremia", "Eségiël", "Daniël", "Hoséa", "Joël", "Amos",
+            "Obadja", "Jona", "Miga", "Nahum", "Hábakuk", "Sefánja", "Haggai", "Sagaria", "Maleági",
+            "Matthéüs", "Markus", "Lukas", "Johannes", "Die handelinge van die apostels", "Romeine", "1 Korinthiërs",
+            "2 Korinthiërs", "Galásiërs", "Efésiërs", "Filippense", "Kolossense", "1 Tessalonisense", "2 Tessalonisense",
+            "1 Timótheüs", "2 Timótheüs", "Titus", "Filémon", "Hebreërs", "Jakobus", "1 Petrus", "2 Petrus", "1 Johannes",
+            "2 Johannes", "3 Johannes", "Judas", "Openbaring", NULL
 	  };


### PR DESCRIPTION
Fixed the book names to match the official translation's spelling. 

What I left unchanged was the numbering convention. The offical translation has the convention of numbering books with capital roman numerals, for example "II Petrus" instead of "2 Petrus".